### PR TITLE
Update the spack containers build to provide custom env vars 

### DIFF
--- a/spack-env/spack.yaml
+++ b/spack-env/spack.yaml
@@ -21,7 +21,7 @@ spack:
           set:
             '{name}_ROOT': '{prefix}'
       projections:
-        all: '{name}'/'{version}'
+        all: '{name}/{version}'
       netcdf-c:
         environment:
           set:


### PR DESCRIPTION
There currently doesn't seem to be a way to export custom environment variables using spack except through the compiler configuration (which may only be during package install?) or through the use of spack's modulefile generation.